### PR TITLE
Fix the declaration of the switchState function to support states with parameters

### DIFF
--- a/include/otest2/controls.h
+++ b/include/otest2/controls.h
@@ -43,8 +43,9 @@ namespace Controls {
  * @param delay_ Delay in milliseconds between end of the current state
  *     and run of the next state.
  */
+template<typename... Args_>
 void switchState(
-    void (*state_)(),
+    void (*state_)(Args_... args_),
     int delay_) TEST_CONTROLS_SWITCH_STATE();
 
 }  /* -- namespace Controls */

--- a/test/mainloop.ot2
+++ b/test/mainloop.ot2
@@ -63,6 +63,26 @@ TEST_SUITE(MainLoopSuite) {
 //      runtime.reporter.dumpRecords(std::cout);
     }
   }
+
+  TEST_CASE(Bug22) {
+    /* -- The switchState function has accepted a pointer to a function
+     *    with no arguments. If the state had had some user data or the
+     *    OTest2 context parameters the switching would have not able
+     *    to compile. */
+    int loop(0);
+
+    void firstState(
+        const Context& context_) OT2_STATE() {
+      if(loop < 1) {
+        testAssertEqual(loop, 0);
+        ++loop;
+        switchState(firstState, 10);
+      }
+      else {
+        testAssertEqual(loop, 1);
+      }
+    }
+  }
 }
 
 } /* -- namespace Test */


### PR DESCRIPTION
The function is declared as a template function accepting a type pack for arguments.

Fixing of the bug #24 