### PR TITLE
Expression Assertion

### DIFF
--- a/docs/_examples/quick-start.md
+++ b/docs/_examples/quick-start.md
@@ -23,12 +23,26 @@ TEST_SUITE(QuickStart) {
       testAssertEqual(10, 9);
     }
   }
+
+  TEST_CASE(TestExpression) {
+    TEST_SIMPLE() {
+      testAssertExpr(std::string("hello").length() == 6);
+    }
+  }
 }
 {% endhighlight %}
 
-The file describes one test suite _QuickStart_ containing two test cases:
+The file describes one test suite _QuickStart_ containing three test cases:
 _TestOK_ and _TestFailed_. The first case should pass, the second one should
 fail.
+
+The third test case shows a special assertion `testAssertExpr` which parses
+relational operators in the specified expression and it's able to print
+both operands. In this case the string is not 6 characters long so the
+test case fails.
+
+See [the reference page]({{ "reference/assertions/" | relative_url }})
+to explore the entire rich set of assertions offered by the framework.
 
 The OTest2 framework offers a cmake package, so the test can be easily used
 in your cmake project:
@@ -81,6 +95,11 @@ ck 'a == b' has failed
     a = 10
     b = 9
   TestFailed                                                          [Failed]
+[.../examples/quick-start/quick.ot2:37] quick-start::QuickStart::TestExpression:
+check 'a == b' has failed
+    a = 5
+    b = 6
+  TestExpression                                                      [Failed]
  ------------------------------------------------------------------------------
   Suite total                                                         [Failed]
  ================================ Test results ================================

--- a/docs/reference/assertions.md
+++ b/docs/reference/assertions.md
@@ -16,6 +16,25 @@ Assertions for general usage. The assertion passes when the condition is
 true. The [`AssertBean`]({{ "api/html/classOTest2_1_1AssertBean.html" | relative_url }})
 can be used by helper methods to report some meaningful message.
 
+### Expression Assertion
+
+There is one special assertion
+```c++
+bool testAssertExpr(bool condition_);
+```
+It's signature is exactly the same as the generic assertion `testAssert`.
+The difference is that OTest2 pre-processor parses expression passed as
+the parameter. If the root operator of the expression is one of the relational
+operators the assertion is handled exactly as
+[the relational assertions](#relational-assertions) are.
+
+This is an implementation of the commont feature present in the 
+[Boost](https://www.boost.org/doc/libs/1_73_0/libs/test/doc/html/index.html)
+or [Catch2](https://github.com/catchorg/Catch2). However, as it's usual
+in the OTest2 framework, the feature is much cleaner. The pre-processor
+just parses the AST and there are no dirty tricks with templates and stealing
+of operands from the expression by prepending some text. 
+
 ## Relational Assertions
 
 ```c++

--- a/examples/quick-start/quick.ot2
+++ b/examples/quick-start/quick.ot2
@@ -31,4 +31,10 @@ TEST_SUITE(QuickStart) {
       testAssertEqual(10, 9);
     }
   }
+
+  TEST_CASE(TestExpression) {
+    TEST_SIMPLE() {
+      testAssertExpr(std::string("hello").length() == 6);
+    }
+  }
 }

--- a/include/otest2/assertionannotation.h
+++ b/include/otest2/assertionannotation.h
@@ -24,11 +24,13 @@
 
 #define TEST_ASSERTION_MARK(class_, method_)
 #define TEST_ASSERTION_MARK_TMPL(class_, method_)
+#define TEST_ASSERTION_EXPR_MARK(class_, generic_method_, comparison_method_)
 
 #else /* -- OTEST2_PARSER_ACTIVE */
 
 #define TEST_ASSERTION_MARK(class_, method_) __attribute__((annotate("otest2::assertion(" #class_ ";" #method_ ")")))
 #define TEST_ASSERTION_MARK_TMPL(class_, method_) __attribute__((annotate("otest2::assertion(" class_ ";" method_ ")")))
+#define TEST_ASSERTION_EXPR_MARK(class_, generic_method_, comparison_method_) __attribute__((annotate("otest2::assertionExpr(" class_ ";" generic_method_ ";" comparison_method_ ")")))
 
 #endif /* -- OTEST2_PARSER_ACTIVE */
 

--- a/include/otest2/assertions.h
+++ b/include/otest2/assertions.h
@@ -100,6 +100,23 @@ bool testAssert(
     const AssertBean& bean_) TEST_ASSERTION_MARK(::OTest2::GenericAssertion, testAssert);
 
 /**
+ * @brief Generic assertion with parsed expression
+ *
+ * This assertion function parses specified boolean expression. If the root
+ * operator one of the relational operators (==, != etc.) it will separate
+ * left and right operands and it will process the assertion as the relational
+ * assertion testAssertCmp().
+ *
+ * If the root operator is not any of the relational operators the assertion
+ * works as the generic testAssert() function.
+ *
+ * @param expression_ The boolean expression
+ * @return Value of the boolean expression
+ */
+bool testAssertExpr(
+    bool expression_) TEST_ASSERTION_EXPR_MARK("::OTest2::GenericAssertion", "testAssert", "testAssertCompare< ::$1 >");
+
+/**
  * @brief Generic comparison assertion
  *
  * @tparam Compare_ The comparison template

--- a/otest2/generator.h
+++ b/otest2/generator.h
@@ -74,6 +74,13 @@ class Generator {
         const Location& begin_,
         const Location& end_) = 0;
 
+    struct AssertionArg {
+        Location begin;    /**< beginning location of the argument */
+        Location end;      /**< ending location of the argument */
+        bool append_comma; /**< if it's true the command will be appended
+                                the argument. */
+    };
+
     /**
      * @brief Make a test assertion
      *
@@ -83,17 +90,13 @@ class Generator {
      *
      * @param assertion_class_ Name of the assertion class
      * @param assertion_method_ Name of the assertion method
-     * @param begin_ Beginning location of the assertion arguments.
-     * @param end_ Ending location of the assertion arguments.
-     * @param expr_end_ Ending location of the checked expression.
-     *     The expression is expected in the range <begin_, expr_end_)
+     * @param args_ranges_ Ordered ranges of assertion arguments. The first
+     *     range is used as a message in the generic assertion functions.
      */
     virtual void makeAssertion(
         const std::string& assertion_class_,
         const std::string& assertion_method_,
-        const Location& begin_,
-        const Location& end_,
-        const Location& expr_end_) = 0;
+        const std::vector<AssertionArg>& args_ranges_) = 0;
 
     /**
      * @brief Generate state switch
@@ -101,7 +104,7 @@ class Generator {
      * @param state_begin_ Beginning location of the state name
      * @param state_end_ Ending location of the state name
      * @param delay_begin_ Beginning location of the delay expression
-     * @param delay_end_ End locatino of the delay expression
+     * @param delay_end_ End location of the delay expression
      */
     virtual void makeStateSwitch(
         const Location& state_begin_,

--- a/otest2/generatorstd.h
+++ b/otest2/generatorstd.h
@@ -75,9 +75,7 @@ class GeneratorStd : public Generator {
     virtual void makeAssertion(
         const std::string& assertion_class_,
         const std::string& assertion_method_,
-        const Location& begin_,
-        const Location& end_,
-        const Location& expr_end_) override;
+        const std::vector<AssertionArg>& args_ranges_) override;
     virtual void makeStateSwitch(
         const Location& state_begin_,
         const Location& state_end_,

--- a/otest2/parserannotation.cpp
+++ b/otest2/parserannotation.cpp
@@ -28,6 +28,7 @@ const std::string STATE_ANNOTATION("otest2::state");
 const std::string START_UP_ANNOTATION("otest2::startUp");
 const std::string TEAR_DOWN_ANNOTATION("otest2::tearDown");
 const std::string ASSERTION_ANNOTATION("^otest2::assertion[(](.*)[)]$");
+const std::string ASSERTION_EXPR_ANNOTATION("^otest2::assertionExpr[(](.*)[)]$");
 const std::string SWITCH_STATE_ANNOTATION("otest2::switchState");
 const std::string CATCH_ANNOTATION("otest2::catch");
 const std::string USER_DATA_VAR_ANNOTATION("^otest2::userData[(](.*)[)]$");

--- a/otest2/parserannotation.h
+++ b/otest2/parserannotation.h
@@ -39,6 +39,7 @@ extern const std::string STATE_ANNOTATION;
 extern const std::string START_UP_ANNOTATION;
 extern const std::string TEAR_DOWN_ANNOTATION;
 extern const std::string ASSERTION_ANNOTATION;
+extern const std::string ASSERTION_EXPR_ANNOTATION;
 extern const std::string SWITCH_STATE_ANNOTATION;
 extern const std::string CATCH_ANNOTATION;
 extern const std::string USER_DATA_VAR_ANNOTATION;

--- a/otest2/parserassert.cpp
+++ b/otest2/parserassert.cpp
@@ -34,6 +34,19 @@ namespace OTest2 {
 
 namespace Parser {
 
+namespace {
+
+std::vector<std::string> parseAnnotationArguments(
+    const AnnotationRegex& cmp_) {
+  auto annot_args_(cmp_.matches[1].str());
+  std::regex split_("(;)");
+  std::sregex_token_iterator iter_(
+      annot_args_.begin(), annot_args_.end(), split_, -1);
+  return std::vector<std::string>(iter_, std::sregex_token_iterator());
+}
+
+} /* -- namespace */
+
 AssertVisitor::AssertVisitor(
     ParserContext* context_,
     const Location& curr_) :
@@ -45,6 +58,251 @@ AssertVisitor::AssertVisitor(
 
 AssertVisitor::~AssertVisitor() {
 
+}
+
+bool AssertVisitor::generateAssertion(
+    clang::CallExpr* expr_,
+    clang::Decl* declref_,
+    clang::FunctionDecl* fce_,
+    std::string class_arg_,
+    std::string method_arg_,
+    std::vector<std::string> template_params_,
+    std::vector<Generator::AssertionArg> args_ranges_,
+    int ignored_params_) {
+  /* -- if the function is a template function, expand the list of template
+   *    parameters by the deduced types. */
+  if(fce_->isTemplateInstantiation()) {
+    const clang::TemplateArgumentList* args_(fce_->getTemplateSpecializationArgs());
+    if(args_ != nullptr) {
+      for(int i_(0); i_ < static_cast<int>(args_->size()); ++i_) {
+        const auto& arg_(args_->get(i_));
+        if(arg_.getKind() == clang::TemplateArgument::Type) {
+          auto type_(arg_.getAsType());
+          template_params_.push_back(type_.getAsString());
+        } else if(arg_.getKind() == clang::TemplateArgument::Template) {
+          auto templ_(arg_.getAsTemplate().getAsTemplateDecl());
+          template_params_.push_back(parseType(context, *templ_));
+        }
+      }
+    }
+  }
+
+  /* -- expand the assertion templates */
+  if(!expandTemplate(class_arg_, template_params_)) {
+    context->setError("invalid type template of the assertion class", declref_);
+    return false;
+  }
+  if(!expandTemplate(method_arg_, template_params_)) {
+    context->setError("invalid type template of the assertion method", declref_);
+    return false;
+  }
+
+  /* -- copy source just before the assertion */
+  clang::SourceRange expr_range_(context->getNodeRange(expr_));
+  auto expr_begin_(context->createLocation(expr_range_.getBegin()));
+  context->generator->copySource(current, expr_begin_);
+
+  /* -- find first and last non-default argument */
+  const int argnum_(expr_->getNumArgs());
+  int last_index_(-1);
+  for(int i_(0); i_ < argnum_; ++i_) {
+    clang::Expr *arg_(expr_->getArg(i_));
+    if(clang::isa<clang::CXXDefaultArgExpr>(arg_))
+      break;
+    last_index_ = i_;
+  }
+  if(last_index_ < 0 || last_index_ < (ignored_params_ - 1)) {
+    context->setError("there are not enough arguments of the assertion", fce_);
+    return false;
+  }
+
+  /* -- Get range of the source code containing assertion's parameters.
+   *    A couple of first parameters may be ignored (they are parsed by
+   *    the expression assertion functions. */
+  auto endarg_(expr_->getArg(last_index_));
+  clang::SourceRange endrange_(context->getNodeRange(endarg_));
+  auto args_end_(context->createLocation(endrange_.getEnd()));
+  if(last_index_ >= ignored_params_) {
+    /* -- if there are some not ignored parameters add them into the list
+     *    of parameter ranges in the source file. */
+    auto begarg_(expr_->getArg(ignored_params_));
+    clang::SourceRange begrange_(context->getNodeRange(begarg_));
+    /* -- first parameter is used as a message in the generic assertions */
+    args_ranges_.push_back({
+        context->createLocation(begrange_.getBegin()),
+        context->createLocation(begrange_.getEnd()),
+        false});
+    args_ranges_.push_back({
+        context->createLocation(begrange_.getEnd()),
+        args_end_,
+        false});
+  }
+  context->generator->makeAssertion(class_arg_, method_arg_, args_ranges_);
+
+  /* -- keep last position for next source copying */
+  current = args_end_;
+
+  return true;
+
+}
+
+bool AssertVisitor::visitAssertion(
+    clang::CallExpr* expr_,
+    clang::Decl* declref_,
+    clang::FunctionDecl* fce_,
+    const AnnotationRegex& cmp_) {
+  /* -- split the annotation arguments */
+  std::vector<std::string> annotation_args_(parseAnnotationArguments(cmp_));
+  if(annotation_args_.size() != 2) {
+    context->setError("invalid count of the arguments of the assertion annotation", declref_);
+    return false;
+  }
+
+  /* -- generate the assertion */
+  return generateAssertion(
+      expr_,
+      declref_,
+      fce_,
+      annotation_args_[0],
+      annotation_args_[1],
+      std::vector<std::string>(),
+      std::vector<Generator::AssertionArg>(),
+      0);
+}
+
+bool AssertVisitor::visitAssertionExpr(
+    clang::CallExpr* expr_,
+    clang::Decl* declref_,
+    clang::FunctionDecl* fce_,
+    const AnnotationRegex& cmp_) {
+  /* -- split the annotation arguments:
+   *       0: assertion class
+   *       1: generic asssertion function
+   *       2: comparison assertion function
+   */
+  std::vector<std::string> annotation_args_(parseAnnotationArguments(cmp_));
+  if(annotation_args_.size() != 3) {
+    context->setError("invalid count of the arguments of the assertion annotation", declref_);
+    return false;
+  }
+
+  /* -- Parse the expression passed as the first argument. Firstly, ignore
+   *    parenthesis wrapping the expression. */
+  auto firstarg_(expr_->getArg(0));
+  while(clang::isa<clang::ParenExpr>(firstarg_)) {
+    auto par_expr_(clang::cast<clang::ParenExpr>(firstarg_));
+    firstarg_ = par_expr_->getSubExpr();
+  }
+
+  /* -- If the root operator is a relation operator redirect the assertion
+   *    to the comparison method with a selected comparator type. Otherwise,
+   *    use the generic assertion method. */
+  std::vector<std::string> template_args_;
+  std::vector<Generator::AssertionArg> args_ranges_;
+  int ignored_args_(0);
+  int method_index_(1);
+  if(clang::isa<clang::BinaryOperator>(firstarg_)) {
+    auto oper_(clang::cast<clang::BinaryOperator>(firstarg_));
+    std::string comparator_;
+    switch(oper_->getOpcode()) {
+      case clang::BO_EQ:
+        comparator_ = "Equal";
+        break;
+      case clang::BO_NE:
+        comparator_ = "NotEqual";
+        break;
+      case clang::BO_LT:
+        comparator_ = "Less";
+        break;
+      case clang::BO_LE:
+        comparator_ = "LessOrEqual";
+        break;
+      case clang::BO_GT:
+        comparator_ = "Greater";
+        break;
+      case clang::BO_GE:
+        comparator_ = "GreaterOrEqual";
+        break;
+      default:
+        break;
+    }
+
+    if(!comparator_.empty()) {
+      /* -- source ranges of the operands */
+      auto left_(oper_->getLHS());
+      clang::SourceRange leftrange_(context->getNodeRange(left_));
+      args_ranges_.push_back({
+          context->createLocation(leftrange_.getBegin()),
+          context->createLocation(leftrange_.getEnd()),
+          true});
+      auto right_(oper_->getRHS());
+      clang::SourceRange rightrange_(context->getNodeRange(right_));
+      args_ranges_.push_back({
+          context->createLocation(rightrange_.getBegin()),
+          context->createLocation(rightrange_.getEnd()),
+          true});
+
+      /* -- add the comparator into the template parameters */
+      template_args_.push_back("OTest2::" + comparator_);
+
+      /* -- ignore the first argument - I have already parsed it */
+      ignored_args_ = 1;
+
+      /* -- select the comparison method */
+      method_index_ = 2;
+    }
+  }
+
+  /* -- generate the assertion */
+  return generateAssertion(
+      expr_,
+      declref_,
+      fce_,
+      annotation_args_[0],
+      annotation_args_[method_index_],
+      template_args_,
+      args_ranges_,
+      ignored_args_);
+}
+
+bool AssertVisitor::visitSwitchState(
+    clang::CallExpr* expr_,
+    clang::Decl* declref_,
+    clang::FunctionDecl* fce_) {
+  /* -- find first and last non-default argument */
+  const int argnum_(expr_->getNumArgs());
+  if(argnum_ != 2) {
+    context->setError("invalid count of the state switching function", fce_);
+    return false;
+  }
+
+  /* -- copy source just before the state switch */
+  clang::SourceRange expr_range_(context->getNodeRange(expr_));
+  auto expr_begin_(context->createLocation(expr_range_.getBegin()));
+  auto expr_end_(context->createLocation(expr_range_.getEnd()));
+  context->generator->copySource(current, expr_begin_);
+
+  /* -- get the arguments */
+  auto state_(expr_->getArg(0));
+  clang::SourceRange state_range_(context->getNodeRange(state_));
+  auto state_begin_(context->createLocation(state_range_.getBegin()));
+  auto state_end_(context->createLocation(state_range_.getEnd()));
+  auto delay_(expr_->getArg(1));
+  clang::SourceRange delay_range_(context->getNodeRange(delay_));
+  auto delay_begin_(context->createLocation(delay_range_.getBegin()));
+  auto delay_end_(context->createLocation(delay_range_.getEnd()));
+
+  /* -- generate the state switch */
+  context->generator->makeStateSwitch(
+      state_begin_,
+      state_end_,
+      delay_begin_,
+      delay_end_);
+
+  /* -- keep last position for next source copying */
+  current = expr_end_;
+
+  return true;
 }
 
 bool AssertVisitor::VisitCallExpr(
@@ -67,130 +325,21 @@ bool AssertVisitor::VisitCallExpr(
   if(!clang::isa<clang::FunctionDecl>(declref_))
     return true;
 
+  /* -- parse name of the assertion */
+  auto fce_(clang::cast<clang::FunctionDecl>(declref_));
+
   /* -- check the assertion annotation */
   AnnotationRegex cmp_(ASSERTION_ANNOTATION);
-  if(hasAnnotation(declref_, cmp_)) {
-    /* -- split the annotation arguments */
-    auto annot_args_(cmp_.matches[1].str());
-    std::regex split_("(;)");
-    std::sregex_token_iterator iter_(
-        annot_args_.begin(), annot_args_.end(), split_, -1);
-    std::vector<std::string> annotation_args_(iter_, std::sregex_token_iterator());
-    if(annotation_args_.size() != 2) {
-      context->setError("invalid count of the arguments of the assertion annotation", declref_);
-      return false;
-    }
+  if(hasAnnotation(declref_, cmp_))
+    return visitAssertion(expr_, declref_, fce_, cmp_);
 
-    /* -- parse name of the assertion */
-    auto fce_(clang::cast<clang::FunctionDecl>(declref_));
-    auto fcename_(fce_->getName().str());
-
-    /* -- if the function is a template function, expand deduced types into
-     *    the annotation parameters. */
-    if(fce_->isTemplateInstantiation()) {
-      const clang::TemplateArgumentList* args_(fce_->getTemplateSpecializationArgs());
-      if(args_ != nullptr) {
-        std::vector<std::string> template_params_;
-        for(int i_(0); i_ < static_cast<int>(args_->size()); ++i_) {
-          const auto& arg_(args_->get(i_));
-          if(arg_.getKind() == clang::TemplateArgument::Type) {
-            auto type_(arg_.getAsType());
-            template_params_.push_back(type_.getAsString());
-          } else if(arg_.getKind() == clang::TemplateArgument::Template) {
-            auto templ_(arg_.getAsTemplate().getAsTemplateDecl());
-            template_params_.push_back(parseType(context, *templ_));
-          }
-        }
-        if(!expandTemplates(annotation_args_, template_params_)) {
-          context->setError("invalid type template in the annotation of the assertion", declref_);
-          return false;
-        }
-      }
-    }
-
-    /* -- find first and last non-default argument */
-    const int argnum_(expr_->getNumArgs());
-    int last_index_(-1);
-    for(int i_(0); i_ < argnum_; ++i_) {
-      clang::Expr *arg_(expr_->getArg(i_));
-      if(clang::isa<clang::CXXDefaultArgExpr>(arg_))
-        break;
-      last_index_ = i_;
-    }
-    if(last_index_ < 0) {
-      context->setError("there are no arguments of the assertion", fce_);
-      return false;
-    }
-
-    /* -- copy source just before the assertion */
-    clang::SourceRange expr_range_(context->getNodeRange(expr_));
-    auto expr_begin_(context->createLocation(expr_range_.getBegin()));
-    context->generator->copySource(current, expr_begin_);
-
-    /* -- Generate the assertion. I need to know the range of arguments
-     *    because I want to insert the first argument as a text (to be shown
-     *    in the assertion message. */
-    auto begarg_(expr_->getArg(0));
-    auto endarg_(expr_->getArg(last_index_));
-    clang::SourceRange begrange_(context->getNodeRange(begarg_));
-    clang::SourceRange endrange_(context->getNodeRange(endarg_));
-    auto args_begin_(context->createLocation(begrange_.getBegin()));
-    auto args_end_(context->createLocation(endrange_.getEnd()));
-    auto msg_end_(context->createLocation(begrange_.getEnd()));
-    context->generator->makeAssertion(
-        annotation_args_[0],
-        annotation_args_[1],
-        args_begin_,
-        args_end_,
-        msg_end_);
-
-    /* -- keep last position for next source copying */
-    current = args_end_;
-
-    return true;
-  }
+  AnnotationRegex cmp_expr_(ASSERTION_EXPR_ANNOTATION);
+  if(hasAnnotation(declref_, cmp_expr_))
+    return visitAssertionExpr(expr_, declref_, fce_, cmp_expr_);
 
   /* -- check the switchState annotation */
-  if(hasAnnotation(declref_, SWITCH_STATE_ANNOTATION)) {
-    /* -- parse name of the assertion */
-    auto fce_(clang::cast<clang::FunctionDecl>(declref_));
-    auto fcename_(fce_->getName().str());
-
-    /* -- find first and last non-default argument */
-    const int argnum_(expr_->getNumArgs());
-    if(argnum_ != 2) {
-      context->setError("invalid count of the state switching function", fce_);
-      return false;
-    }
-
-    /* -- copy source just before the state switch */
-    clang::SourceRange expr_range_(context->getNodeRange(expr_));
-    auto expr_begin_(context->createLocation(expr_range_.getBegin()));
-    auto expr_end_(context->createLocation(expr_range_.getEnd()));
-    context->generator->copySource(current, expr_begin_);
-
-    /* -- get the arguments */
-    auto state_(expr_->getArg(0));
-    clang::SourceRange state_range_(context->getNodeRange(state_));
-    auto state_begin_(context->createLocation(state_range_.getBegin()));
-    auto state_end_(context->createLocation(state_range_.getEnd()));
-    auto delay_(expr_->getArg(1));
-    clang::SourceRange delay_range_(context->getNodeRange(delay_));
-    auto delay_begin_(context->createLocation(delay_range_.getBegin()));
-    auto delay_end_(context->createLocation(delay_range_.getEnd()));
-
-    /* -- generate the state switch */
-    context->generator->makeStateSwitch(
-        state_begin_,
-        state_end_,
-        delay_begin_,
-        delay_end_);
-
-    /* -- keep last position for next source copying */
-    current = expr_end_;
-
-    return true;
-  }
+  if(hasAnnotation(declref_, SWITCH_STATE_ANNOTATION))
+    return visitSwitchState(expr_, declref_, fce_);
 
   /* -- no special function - let continue */
   return true;

--- a/otest2/parserassert.h
+++ b/otest2/parserassert.h
@@ -22,7 +22,9 @@
 
 #include <clang/AST/RecursiveASTVisitor.h>
 #include <clang/AST/Stmt.h>
+#include <utility>
 
+#include "generator.h"
 #include "location.h"
 #include "parsercontext.h"
 
@@ -30,11 +32,38 @@ namespace OTest2 {
 
 namespace Parser {
 
+struct AnnotationRegex;
+
 class AssertVisitor : public clang::RecursiveASTVisitor<AssertVisitor> {
   private:
     ParserContext* context;
     Location current;
     clang::Stmt* subtree_root;
+
+    bool generateAssertion(
+        clang::CallExpr* expr_,
+        clang::Decl* declref_,
+        clang::FunctionDecl* fce_,
+        std::string class_arg_,
+        std::string method_arg_,
+        std::vector<std::string> template_params_,
+        std::vector<Generator::AssertionArg> args_ranges_,
+        int ignored_params_);
+
+    bool visitAssertion(
+        clang::CallExpr* expr_,
+        clang::Decl* declref_,
+        clang::FunctionDecl* fce_,
+        const AnnotationRegex& cmp_);
+    bool visitAssertionExpr(
+        clang::CallExpr* expr_,
+        clang::Decl* declref_,
+        clang::FunctionDecl* fce_,
+        const AnnotationRegex& cmp_);
+    bool visitSwitchState(
+        clang::CallExpr* expr_,
+        clang::Decl* declref_,
+        clang::FunctionDecl* fce_);
 
   public:
     explicit AssertVisitor(

--- a/otest2/typetemplate.cpp
+++ b/otest2/typetemplate.cpp
@@ -26,6 +26,8 @@
 
 namespace OTest2 {
 
+namespace Parser {
+
 namespace {
 
 class Automaton {
@@ -140,6 +142,7 @@ bool Automaton::step(
       if(c_ >= '0' && c_ <= '9') {
         state = PAR_NUM2;
         argnum = (c_ - '0');
+        return true;
       }
       else {
         return false;
@@ -177,16 +180,16 @@ bool expandTemplate(
   return parser_.step(os_, -1, args_);
 }
 
-bool expandTemplates(
-    std::vector<std::string>& templates_,
+bool expandTemplate(
+    std::string& template_,
     const std::vector<std::string>& args_) {
-  for(auto& template_ : templates_) {
-    std::ostringstream sos_;
-    if(!expandTemplate(sos_, template_, args_))
-      return false;
-    template_ = sos_.str();
-  }
+  std::ostringstream sos_;
+  if(!expandTemplate(sos_, template_, args_))
+    return false;
+  template_ = sos_.str();
   return true;
 }
+
+} /* -- namespace Parser */
 
 } /* namespace OTest2 */

--- a/otest2/typetemplate.h
+++ b/otest2/typetemplate.h
@@ -25,6 +25,8 @@
 
 namespace OTest2 {
 
+namespace Parser {
+
 /**
  * @brief Expand one template
  *
@@ -41,13 +43,15 @@ bool expandTemplate(
 /**
  * @brief Expand one template
  *
- * @param[in,out] templates_ List of the templates to be expanded
+ * @param[in,out] template_ The template
  * @param[in] args_ List of templates' parameters
  * @return False if the templates cannot be parsed
  */
-bool expandTemplates(
-    std::vector<std::string>& templates_,
+bool expandTemplate(
+    std::string& templates_,
     const std::vector<std::string>& args_);
+
+} /* -- namespace Parser */
 
 } /* namespace OTest2 */
 

--- a/test/assertions.ot2
+++ b/test/assertions.ot2
@@ -525,6 +525,54 @@ TEST_SUITE(AssertionsSuite) {
 //      runtime.reporter.dumpRecords(std::cout);
     }
   }
+
+  TEST_CASE(ExpressionAssertion) {
+    Runtime runtime("AssertionsSuite", "ExpressionAssertion");
+
+    TEST_SIMPLE() {
+      std::vector<const char*> data_{
+        "enterTest<selftest>",
+        "enterSuite<AssertionsSuite>",
+        "enterCase<ExpressionAssertion>",
+        "enterState<AnonymousState>",
+        "assert<check 'a == b' has passed>: passed",
+        "message<a = 10>",
+        "message<b = 10>",
+        "leaveAssert<>",
+        "assert<check 'a != b' has passed>: passed",
+        "message<a = 12>",
+        "message<b = 10>",
+        "leaveAssert<>",
+        "assert<check 'a > b' has passed>: passed",
+        "message<a = 10>",
+        "message<b = 5>",
+        "leaveAssert<>",
+        "assert<check 'a >= b' has passed>: passed",
+        "message<a = 10>",
+        "message<b = 5>",
+        "leaveAssert<>",
+        "assert<check 'a < b' has failed>: failed",
+        "message<a = 10>",
+        "message<b = 5>",
+        "leaveAssert<>",
+        "assert<check 'a <= b' has failed>: failed",
+        "message<a = 10>",
+        "message<b = 5>",
+        "leaveAssert<>",
+        "assert<'std::string().empty()'>: passed",
+        "leaveAssert<>",
+        "assert<'!(10 == 15)'>: passed",
+        "leaveAssert<>",
+        "leaveState<AnonymousState>: failed",
+        "leaveCase<ExpressionAssertion>: failed",
+        "leaveSuite<AssertionsSuite>: failed",
+        "leaveTest<selftest>: failed",
+      };
+      testAssert(!runtime.runTheTest());
+      testAssert(runtime.reporter.checkRecords(data_));
+//      runtime.reporter.dumpRecords(std::cout);
+    }
+  }
 }
 
 } /* -- namespace Test */

--- a/test/selftests/assertions.ot2
+++ b/test/selftests/assertions.ot2
@@ -148,6 +148,20 @@ TEST_SUITE(AssertionsSuite) {
       testAssertCmp<LessOrEqual>(10, 10);
     }
   }
+
+  TEST_CASE(ExpressionAssertion) {
+    TEST_SIMPLE() {
+      testAssertExpr(10 == 2 * 5);
+      testAssertExpr(((2 * 6 != 5 + 5)));
+      testAssertExpr(10 > 5);
+      testAssertExpr(10 >= 5);
+      testAssertExpr(10 < 5);
+      testAssertExpr(10
+          <= 5);
+      testAssertExpr(std::string().empty());
+      testAssertExpr(!(10 == 15));
+    }
+  }
 }
 
 } /* -- namespace SelfTest */


### PR DESCRIPTION
A new assertion which parses passed expression and searches for the root operator. If the operator is one of the relational operators the assertion is handled as the same as the relational assertions - the left and right operands are passed separately into the assertion function with an appropriate comparator.

Implementation of the #25 

